### PR TITLE
Make form submission send encoded form, not JSON

### DIFF
--- a/lib/simple_hubspot/api_client.rb
+++ b/lib/simple_hubspot/api_client.rb
@@ -18,8 +18,11 @@ module SimpleHubspot
       end
 
       def do_form_post(guid = nil, params = {}, headers = {})
+        if params[:hs_context]
+          params[:hs_context] = params[:hs_context].to_json
+        end
         response = RestClient.post "#{SimpleHubspot.configuration.form_submit_base}#{SimpleHubspot.configuration.portal_id}/#{guid}",
-                                   params.to_json,
+                                   URI.encode_www_form(params),
                                    { content_type: 'application/x-www-form-urlencoded'}
         response_success response.body
       rescue RestClient::BadRequest => e

--- a/lib/simple_hubspot/form.rb
+++ b/lib/simple_hubspot/form.rb
@@ -5,7 +5,7 @@ module SimpleHubspot
 
       def submit_form(guid, params)
         raise ArgumentError unless guid
-        ApiClient.do_form_post guid, { properties: Utils.hash_to_properties(params) }
+        ApiClient.do_form_post guid, params
       end
     end
 

--- a/spec/simple_hubspot/form_spec.rb
+++ b/spec/simple_hubspot/form_spec.rb
@@ -12,7 +12,7 @@ describe SimpleHubspot::Form do
     context 'when submit success' do
       before do
         stub_request(:post, "https://forms.hubspot.com/uploads/form/v2/PORTAL_ID/FORM_ID")
-        .with(body: /^.*$/, headers: { "Content-Type" => "application/x-www-form-urlencoded" })
+        .with(body: /^.*$/, headers: { "Content-Type" => "application/x-www-form-urlencoded" }, body: URI.encode_www_form(expected_request))
         .to_return(status: 204)
 
         @payload = { email: 'test@example.com', 
@@ -22,6 +22,11 @@ describe SimpleHubspot::Form do
                                   pageName: 'Contact Us' } }
       end
       let(:response) { SimpleHubspot::Form.submit_form 'FORM_ID', @payload }
+      let(:expected_request) { { email: 'test@example.com',
+                                  hs_context: ({ hutk: '60c2ccdfe4892f0fa0593940b12c11aa',
+                                                ipAddress: '127.0.0.10',
+                                                pageUrl: 'http://demo.hubapi.com/contact/',
+                                                pageName: 'Contact Us' }).to_json } }
 
       it { expect(response[:success]).to be_truthy }
     end
@@ -39,7 +44,6 @@ describe SimpleHubspot::Form do
                                   pageName: 'Contact Us' } }
       end
       let(:response) { SimpleHubspot::Form.submit_form 'FORM_ID', @payload }
-
       it { expect(response[:success]).to be_falsy }
     end
 


### PR DESCRIPTION
Apologies, upon use this needed to be fixed.
